### PR TITLE
Updating the auth package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React Serverless Authentication Components Example
 [![Build Status](https://travis-ci.org/stanchino/react-serverless-auth-example.svg?branch=master)](https://travis-ci.org/stanchino/react-serverless-auth-example)
 [![Coverage Status](https://coveralls.io/repos/github/stanchino/react-serverless-auth-example/badge.svg?branch=master)](https://coveralls.io/github/stanchino/react-serverless-auth-example?branch=master)
+[![dependencies Status](https://david-dm.org/stanchino/react-serverless-auth-example/status.svg)](https://david-dm.org/stanchino/react-serverless-auth-example)
 [![Maintainability](https://api.codeclimate.com/v1/badges/3fccf3737e4e89a875e0/maintainability)](https://codeclimate.com/github/stanchino/react-serverless-auth-example/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/3fccf3737e4e89a875e0/test_coverage)](https://codeclimate.com/github/stanchino/react-serverless-auth-example/test_coverage)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "next",
     "react-scripts": "^1.1.0",
-    "react-serverless-auth": "https://github.com/stanchino/react-serverless-auth.git#development",
+    "react-serverless-auth": "^1.5.0",
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5713,9 +5713,9 @@ react-scripts@^1.1.0:
   optionalDependencies:
     fsevents "^1.1.3"
 
-"react-serverless-auth@https://github.com/stanchino/react-serverless-auth.git#development":
-  version "0.0.0-development"
-  resolved "https://github.com/stanchino/react-serverless-auth.git#c63e58e3880f0adab5f399ea9dcb1f353e7e4526"
+react-serverless-auth@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-serverless-auth/-/react-serverless-auth-1.5.0.tgz#ded9027501d0422fe95a8fcd4aa17e9001ffd5cd"
   dependencies:
     amazon-cognito-identity-js "^1.31.0"
     aws-sdk "^2.188.0"


### PR DESCRIPTION
Remove GitHub references for the react-serverless-auth package version

## Proposed changes

  - Update the react-serverless-auth version to use the NPM package
  - Add a dependencies badge to track outdated dependencies